### PR TITLE
Add Visual Computing seminar deck and README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Description
+Brief description of changes made.
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Code improvement
+
+## Testing
+- [ ] Tested locally
+- [ ] All tests pass
+- [ ] Documentation updated
+
+## Checklist
+- [ ] Code follows project style guidelines
+- [ ] Self-review completed
+- [ ] Changes are well documented

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+## Enforcement
+
+Project maintainers are responsible for clarifying standards and are expected to take appropriate action in response to any instances of unacceptable behavior.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to this Visual Computing seminar project!
+
+## How to Contribute
+
+### Reporting Issues
+- Use the GitHub issue tracker to report problems or suggest improvements
+- Provide clear descriptions and steps to reproduce any issues
+- Include relevant screenshots or examples when applicable
+
+### Suggesting Enhancements
+- Open an issue with the "enhancement" label
+- Describe the proposed improvement and its benefits
+- Consider the educational value for Visual Computing students
+
+### Code Contributions
+- Fork the repository and create a feature branch
+- Follow existing code style and documentation standards
+- Test any code additions thoroughly
+- Submit a pull request with a clear description
+
+## Development Setup
+
+1. Clone the repository
+2. Install any required dependencies
+3. Make your changes in a feature branch
+4. Test thoroughly before submitting
+
+## Pull Request Process
+
+1. Update documentation for any significant changes
+2. Ensure all tests pass
+3. Request review from project maintainers
+4. Address any feedback promptly
+
+## Code of Conduct
+
+This project follows the standard GitHub Community Guidelines. Please be respectful and constructive in all interactions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shaurya Parshad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,93 @@
-# cnn-object-recognition-seminar
-Visual Computing seminar presentation on CNNs for object recognition and the Dynamic Dual-Processing framework
+# CNN for Object Recognition
+
+![License](https://img.shields.io/badge/license-MIT-blue.svg)
+![Last Update](https://img.shields.io/badge/last%20update-September%202025-green.svg)
+![Issues](https://img.shields.io/github/issues/IShauryaI/cnn-object-recognition-seminar)
+
+**A Visual Computing seminar exploring Convolutional Neural Networks for object recognition and the Dynamic Dual-Processing framework inspired by brain mechanisms.**
+
+## Executive Summary
+
+This presentation examines the evolution of computer vision from traditional CNNs to modern hybrid approaches. The focus centers on the Dynamic Dual-Processing (DDP) framework by Zhang et al. (2023), which combines CNN local feature extraction with Transformer global context understanding. This brain-inspired approach achieves state-of-the-art performance on MS COCO dataset while maintaining computational efficiency, demonstrating 46% fewer FLOPs than comparable models while achieving similar accuracy.
+
+## Table of Contents
+
+- [Slide Preview](#slide-preview)
+- [Key Topics](#key-topics)
+- [Learning Outcomes](#learning-outcomes)
+- [Architecture Overview](#architecture-overview)
+- [References](#references)
+- [License](#license)
+
+## Slide Preview
+
+| Preview | Description |
+|---------|--------------|
+| ![Slide 1](./slides/preview_1.png) | Introduction to CNNs for Object Recognition |
+| ![Slide 2](./slides/preview_2.png) | DDP Framework Architecture |
+| ![Slide 3](./slides/preview_3.png) | Experimental Results and Performance |
+
+📄 **[Download Full Presentation (PDF)](./slides/deck.pdf)**
+
+## Key Topics
+
+- **Convolutional Neural Networks**: Bio-inspired hierarchical feature extraction for visual data processing
+- **Vision Transformers**: Self-attention mechanisms adapted for image understanding and global context
+- **Dynamic Dual-Processing Framework**: Brain-inspired hybrid approach combining CNN and Transformer strengths
+- **Object Detection Architectures**: Comparison of CNN-based (YOLO, Faster R-CNN) vs Transformer approaches
+- **Neural Architecture Search**: Automated optimization for feature fusion between CNN and Transformer streams
+
+## Learning Outcomes
+
+**For Classmates**: Understand the complementary strengths of CNNs and Transformers in computer vision, learn about cutting-edge hybrid architectures, and explore biological inspiration in AI system design.
+
+**For Recruiters**: Demonstrates knowledge of modern computer vision techniques, ability to analyze research papers, understanding of performance optimization in deep learning models, and presentation skills in technical communication.
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    A[Input Image] --> B[Shared Backbone]
+    B --> C[Dual-Stream Encoder]
+    C --> D[CNN Stream<br/>Local Features]
+    C --> E[Transformer Stream<br/>Global Context]
+    D --> F[Feature Fusion<br/>via NAS]
+    E --> F
+    F --> G[Dynamic Dual-Decoder]
+    G --> H[CNN Decoder<br/>Clear Textures]
+    G --> I[Transformer Decoder<br/>Context-dependent]
+    H --> J[Selective Mask]
+    I --> J
+    J --> K[Final Detection Output]
+    
+    style A fill:#e1f5fe
+    style K fill:#c8e6c9
+    style G fill:#fff3e0
+    style J fill:#fce4ec
+```
+
+## References
+
+1. Zhang, M., Bu, T., & Hu, L. (2023). *A Dynamic Dual-Processing Object Detection Framework Inspired by the Brain's Recognition Mechanism*. In Proceedings of the IEEE/CVF International Conference on Computer Vision (ICCV 2023).
+
+2. Berrios, W., & Deza, A. (2022). *Joint Rotational Invariance and Adversarial Training of a Dual-Stream Transformer Yields State of the Art Brain-Score for Area V4*.
+
+📄 **[Primary Paper PDF](./references/ddp-framework-2023.pdf)**  
+📄 **[BibTeX Citations](./references/citations.bib)**
+
+## Course Information
+
+**Course**: COMP-8510 Visual Processing  
+**Institution**: University of Windsor  
+**Presenter**: Shaurya Parshad (SID: 110191553)  
+**Date**: September 2025
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.
+
+## Acknowledgments
+
+- Course instructor and Visual Processing class participants
+- Authors of the Dynamic Dual-Processing framework paper
+- University of Windsor Computer Science Department

--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -1,0 +1,7 @@
+# Documentation Directory
+
+This directory will contain:
+- Additional documentation images
+- Mermaid diagram source files
+- Architecture diagrams
+- Supplementary visual materials

--- a/references/citations.bib
+++ b/references/citations.bib
@@ -1,0 +1,24 @@
+@inproceedings{zhang2023dynamic,
+    title={A Dynamic Dual-Processing Object Detection Framework Inspired by the Brain's Recognition Mechanism},
+    author={Zhang, Minying and Bu, Tianpeng and Hu, Lulu},
+    booktitle={Proceedings of the IEEE/CVF International Conference on Computer Vision (ICCV)},
+    year={2023},
+    organization={IEEE},
+    publisher={IEEE Computer Society},
+    address={Paris, France}
+}
+
+@article{berrios2022joint,
+    title={Joint Rotational Invariance and Adversarial Training of a Dual-Stream Transformer Yields State of the Art Brain-Score for Area V4},
+    author={Berrios, W. and Deza, A.},
+    year={2022}
+}
+
+@misc{parshad2025cnn,
+    title={CNN for Object Recognition: A Visual Computing Seminar},
+    author={Parshad, Shaurya},
+    year={2025},
+    school={University of Windsor},
+    course={COMP-8510 Visual Processing},
+    note={Seminar presentation}
+}

--- a/slides/.gitkeep
+++ b/slides/.gitkeep
@@ -1,0 +1,8 @@
+# Slides Directory
+
+This directory contains:
+- Original PowerPoint presentation (CNN-for-Object-Recognition2222.pptx)
+- Exported PDF version (deck.pdf)
+- Preview images (preview_1.png, preview_2.png, etc.)
+
+Slide assets will be uploaded in the next commit.


### PR DESCRIPTION
This PR adds the complete repository structure for the CNN Object Recognition seminar presentation.

## Changes Added

### Core Files
- **README.md**: Comprehensive documentation with executive summary, architecture diagrams, and learning outcomes
- **LICENSE**: MIT License for open-source sharing
- **CONTRIBUTING.md**: Guidelines for community contributions
- **CODE_OF_CONDUCT.md**: Community standards and behavior expectations

### References
- **citations.bib**: BibTeX citations for the primary DDP framework paper and related work

### GitHub Templates
- Issue templates for bug reports
- Pull request template for structured contributions

### Directory Structure
- `/slides/`: Reserved for PowerPoint, PDF, and preview images
- `/docs/`: Reserved for additional documentation
- `/references/`: Contains citation files
- `/.github/`: Contains community templates

## Features

✅ Professional README with badges and clear navigation  
✅ Mermaid architecture diagram of DDP framework  
✅ IEEE-style references and BibTeX citations  
✅ MIT License for academic/professional use  
✅ Community contribution guidelines  
✅ GitHub issue and PR templates  

## Next Steps (Post-Merge)

1. Upload original PowerPoint file to `/slides/`
2. Convert PPTX to PDF and add preview thumbnails
3. Add primary research paper PDF to `/references/`
4. Optionally implement GitHub Pages for presentation hosting

**Ready for review and merge!**